### PR TITLE
Add list command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,24 @@ Use this subcommand to read the extension payload from Contentful. With this sub
 contentful-extension update [options]
 ```
 Use this subcommand to modify an existing extension.
- 
+
 **delete an extension**
 
 ```
 contentful-extension delete [options]
 ```
 
-Use this subcommand to pertmanently delete an extension from Contentful.
+Use this command to pertmanently delete an extension from Contentful.
 
 For a full list of all the options available on every subcommand use the `--help` option.
+
+**list all extensions**
+
+```
+contentful-extension list [options]
+```
+
+Use this subcommand to see what extensions are created for a given space.
 
 ## Misc
 
@@ -79,7 +87,7 @@ When using `srcdoc` property, an extension is considered internally hosted. A fi
 
 If a relative value of `srcdoc` property is used, the path is resolved from a directory in which the descriptor file is placed or a working directory when using the `--srcdoc` command line option.
 
-Use `src` property when you want to be as flexible as possible with your development and deployment process. Use `srcdoc` property if you don't want to host anything on your own and can accept the drawbacks (need for a non-standard build, filesize limitation). 
+Use `src` property when you want to be as flexible as possible with your development and deployment process. Use `srcdoc` property if you don't want to host anything on your own and can accept the drawbacks (need for a non-standard build, filesize limitation).
 
 #### Specifying extension properties
 

--- a/bin/contentful-extension
+++ b/bin/contentful-extension
@@ -10,7 +10,8 @@ var yargs = require('yargs');
 yargs.command('read')
   .command('update')
   .command('delete')
-  .command('create');
+  .command('create')
+  .command('list');
 
 var argv = yargs.argv;
 var argvCommand = argv._[0];

--- a/bin/contentful-extension-list
+++ b/bin/contentful-extension-list
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('../lib/bin-helpers/command')('list');

--- a/lib/command/list.js
+++ b/lib/command/list.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var Extension = require('../extension');
+var Table = require('cli-table');
+var error = require('./utils/error');
+var formatError = error.format('create');
+
+module.exports = function (options, context) {
+  return Extension.all(options, context)
+    .then(function (extensions) {
+      var table = extensions.items.reduce(function (table, extension) {
+        table.push(
+          [
+            extension.extension.name,
+            extension.sys.id,
+            extension.sys.createdAt,
+            extension.sys.updatedAt
+          ]
+        );
+
+        return table;
+      }, new Table({ head: ['Name', 'Id', 'createdAt', 'updatedAt'] }));
+
+      console.log(table.toString());
+    })
+    .catch(function (err) {
+      console.error(formatError(err.message));
+      process.exit(1);
+    });
+};

--- a/lib/command/list.js
+++ b/lib/command/list.js
@@ -8,20 +8,23 @@ var formatError = error.format('create');
 module.exports = function (options, context) {
   return Extension.all(options, context)
     .then(function (extensions) {
-      var table = extensions.items.reduce(function (table, extension) {
-        table.push(
-          [
-            extension.extension.name,
-            extension.sys.id,
-            extension.sys.createdAt,
-            extension.sys.updatedAt
-          ]
-        );
+      if (extensions.items.length) {
+        console.log('\nCreated extensions are:');
+        var table = extensions.items.reduce(function (table, extension) {
+          table.push(
+            [
+              extension.extension.name, extension.sys.id,
+              extension.sys.createdAt, extension.sys.updatedAt
+            ]
+          );
 
-        return table;
-      }, new Table({ head: ['Name', 'Id', 'createdAt', 'updatedAt'] }));
+          return table;
+        }, new Table({ head: ['Name', 'Id', 'CreatedAt', 'UpdatedAt'] }));
 
-      console.log(table.toString());
+        console.log(table.toString());
+      } else {
+        console.log('\nNo extensions for this space created yet.\n');
+      }
     })
     .catch(function (err) {
       console.error(formatError(err.message));

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "bluebird": "^3.0.5",
+    "cli-table": "^0.3.1",
     "contentful-management": "^0.8.3",
     "lodash": "^3.10.1",
     "yargs": "^3.29.0"

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -43,7 +43,7 @@ describe('Commands', function () {
     execOptions = {env: env};
   });
 
-  ['create', 'update', 'delete', 'read'].forEach(function (subcommand) {
+  ['create', 'update', 'delete', 'read', 'list'].forEach(function (subcommand) {
     describe('when the token is not defined on the environment', function () {
       it(`${subcommand} fails`, function () {
         delete execOptions.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN;
@@ -999,6 +999,34 @@ describe('Commands', function () {
         })
         .then(function (stdout) {
           expect(stdout).to.include('Successfully deleted extension');
+        });
+    });
+  });
+
+  describe('List', function () {
+    it('gives a message when no extensions are created yet', function () {
+      let listCmd = `list --space-id 123 --host http://localhost:3000`;
+
+      return command(listCmd, execOptions)
+        .then(function (stdout) {
+          expect(stdout).to.include('No extensions for this space created yet.');
+        });
+    });
+
+    it('lists created extentions', function () {
+      let createCmd = 'create --space-id 123 --name lol --src lol.com --field-types Symbol --id 456 --host http://localhost:3000';
+      let listCmd = `list --space-id 123 --host http://localhost:3000`;
+
+      return command(createCmd, execOptions)
+        .then(function () {
+          return command(listCmd, execOptions);
+        })
+        .then(function (stdout) {
+          expect(stdout).to.include('lol');
+          expect(stdout).to.include('456');
+        })
+        .catch(function (err) {
+          console.log(err);
         });
     });
   });

--- a/test/integration/http-server.js
+++ b/test/integration/http-server.js
@@ -165,7 +165,9 @@ function createExtension (spaceId, id, payload) {
         sys: {
           id: spaceId
         }
-      }
+      },
+      createdAt: (new Date()).toString(),
+      updatedAt: (new Date()).toString()
     }
   });
 }


### PR DESCRIPTION
This PR brings a `list` command into the cli. Related to https://github.com/contentful/contentful-extension-cli/issues/6

Output for zero extensions:

```
> CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=... contentful-extension list --space-id ...

No extensions for this space created yet.
```

Output for more than one extension:

```
> CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=... contentful-extension list --space-id ...

Created extensions are:
┌─────────────────┬───────────────────────┬──────────────────────────┬──────────────────────────┐
│ Name            │ Id                    │ CreatedAt                │ UpdatedAt                │
├─────────────────┼───────────────────────┼──────────────────────────┼──────────────────────────┤
│ vw-autocomplete │ XcOShl5ieayiUSymm6QMI │ 2016-10-22T12:23:47.366Z │ 2016-10-22T12:23:47.366Z │
└─────────────────┴───────────────────────┴──────────────────────────┴──────────────────────────
```